### PR TITLE
Fix skeleton/validate/stats not finding plan-generated specs

### DIFF
--- a/.specleft/templates/prd-template.yml
+++ b/.specleft/templates/prd-template.yml
@@ -5,13 +5,14 @@ features:
   patterns:
     - "Feature: {title}"
     - "Feature {title}"
+    - "{title}"
   contains: []
   match_mode: "any" # any=pattern OR contains, all=pattern AND contains, patterns=pattern only, contains=contains only
   exclude:
     - "Overview"
     - "Goals"
     - "Non-Goals"
-    - "Open Questions (Post-MVP)"
+    - "Open Questions"
     - "Notes"
 
 scenarios:

--- a/src/specleft/commands/init.py
+++ b/src/specleft/commands/init.py
@@ -23,6 +23,7 @@ features:
   patterns:
     - "Feature: {title}"
     - "Feature {title}"
+    - "{title}"
   contains: []
   match_mode: "any" # any=pattern OR contains, all=pattern AND contains, patterns=pattern only, contains=contains only
   exclude:
@@ -36,6 +37,7 @@ scenarios:
   heading_level: [3, 4]
   patterns:
     - "Scenario: {title}"
+    - "{title}"
   contains: []
   match_mode: "any" # any=pattern OR contains, all=pattern AND contains, patterns=pattern only, contains=contains only
   step_keywords:

--- a/src/specleft/templates/prd_template.py
+++ b/src/specleft/templates/prd_template.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 class PRDFeaturesConfig(BaseModel):
     heading_level: int | list[int] = 2
     patterns: list[str] = Field(
-        default_factory=lambda: ["Feature: {title}", "Feature {title}"]
+        default_factory=lambda: ["Feature: {title}", "Feature {title}", "{title}"]
     )
     contains: list[str] = Field(default_factory=list)
     match_mode: str = "any"
@@ -45,7 +45,9 @@ class PRDFeaturesConfig(BaseModel):
 
 class PRDScenariosConfig(BaseModel):
     heading_level: list[int] = Field(default_factory=lambda: [3, 4])
-    patterns: list[str] = Field(default_factory=lambda: ["Scenario: {title}"])
+    patterns: list[str] = Field(
+        default_factory=lambda: ["Scenario: {title}", "{title}"]
+    )
     contains: list[str] = Field(default_factory=list)
     match_mode: str = "any"
     step_keywords: list[str] = Field(

--- a/tests/commands/test_prd_template.py
+++ b/tests/commands/test_prd_template.py
@@ -24,6 +24,7 @@ class TestPRDTemplate:
         assert template.features.patterns == [
             "Feature: {title}",
             "Feature {title}",
+            "{title}",
         ]
         assert template.features.contains == []
         assert template.features.match_mode == "any"
@@ -35,7 +36,7 @@ class TestPRDTemplate:
             "Notes",
         ]
         assert template.scenarios.heading_level == [3, 4]
-        assert template.scenarios.patterns == ["Scenario: {title}"]
+        assert template.scenarios.patterns == ["Scenario: {title}", "{title}"]
         assert template.scenarios.contains == []
         assert template.scenarios.match_mode == "any"
         assert template.scenarios.step_keywords == [

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from specleft.parser import SpecParser
-from specleft.schema import ExecutionTime, Priority, StepType
+from specleft.schema import ExecutionTime, Priority, SpecsConfig, StepType
 from specleft.validator import collect_spec_stats, load_specs_directory
 
 
@@ -269,3 +269,185 @@ tags: [smoke]
     assert stats.scenario_count == 1
     assert stats.step_count == 3
     assert stats.tags == {"math", "smoke"}
+
+
+# ---------------------------------------------------------------------------
+# Template-aware heading extraction tests (issue #85)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_single_file_with_feature_prefix(tmp_path: Path) -> None:
+    """Parser handles the standard '# Feature: Title' heading."""
+    parser = SpecParser()
+    features_dir = tmp_path / "specs"
+    features_dir.mkdir()
+
+    (features_dir / "auth.md").write_text(
+        "# Feature: User Authentication\n"
+        "\n"
+        "## Scenarios\n"
+        "\n"
+        "### Scenario: Login\n"
+        "priority: high\n"
+        "\n"
+        "- Given a user exists\n"
+        "- When the user logs in\n"
+        "- Then access is granted\n"
+    )
+
+    config = parser.parse_directory(features_dir)
+    assert len(config.features) == 1
+    assert config.features[0].name == "User Authentication"
+    assert config.features[0].feature_id == "auth"
+
+
+def test_parse_single_file_bare_title_falls_back(tmp_path: Path) -> None:
+    """Parser falls back to the raw H1 text when no template pattern matches.
+
+    This is the exact bug from issue #85: ``specleft plan`` generated
+    headings like ``# Document Lifecycle`` (no ``Feature:`` prefix).
+    """
+    parser = SpecParser()
+    features_dir = tmp_path / "specs"
+    features_dir.mkdir()
+
+    (features_dir / "document-lifecycle.md").write_text(
+        "# Document Lifecycle\n"
+        "\n"
+        "## Scenarios\n"
+        "\n"
+        "### Scenario: Create document\n"
+        "priority: medium\n"
+        "\n"
+        "- Given the system is ready\n"
+        "- When a document is created\n"
+        "- Then it should be stored\n"
+    )
+
+    config = parser.parse_directory(features_dir)
+    assert len(config.features) == 1
+    feature = config.features[0]
+    assert feature.name == "Document Lifecycle"
+    assert feature.feature_id == "document-lifecycle"
+    assert len(feature.stories) == 1
+    assert len(feature.stories[0].scenarios) == 1
+
+
+def test_parse_single_file_custom_template_pattern(tmp_path: Path) -> None:
+    """Parser matches a custom PRD template pattern like '{title}'."""
+    from specleft.templates.prd_template import PRDFeaturesConfig, PRDTemplate
+
+    custom_template = PRDTemplate(
+        features=PRDFeaturesConfig(
+            patterns=["{title}"],
+        )
+    )
+    parser = SpecParser(template=custom_template)
+    features_dir = tmp_path / "specs"
+    features_dir.mkdir()
+
+    (features_dir / "billing.md").write_text(
+        "# Billing Module\n"
+        "\n"
+        "## Scenarios\n"
+        "\n"
+        "### Scenario: Charge card\n"
+        "priority: high\n"
+        "\n"
+        "- Given a valid card\n"
+        "- When charging\n"
+        "- Then payment succeeds\n"
+    )
+
+    config = parser.parse_directory(features_dir)
+    assert len(config.features) == 1
+    assert config.features[0].name == "Billing Module"
+
+
+def test_parse_single_file_feature_word_no_colon(tmp_path: Path) -> None:
+    """Parser matches the default 'Feature {title}' pattern (no colon)."""
+    parser = SpecParser()
+    features_dir = tmp_path / "specs"
+    features_dir.mkdir()
+
+    (features_dir / "search.md").write_text(
+        "# Feature Search Engine\n"
+        "\n"
+        "## Scenarios\n"
+        "\n"
+        "### Scenario: Basic search\n"
+        "priority: medium\n"
+        "\n"
+        "- Given indexed documents\n"
+        "- When searching\n"
+        "- Then results appear\n"
+    )
+
+    config = parser.parse_directory(features_dir)
+    assert len(config.features) == 1
+    assert config.features[0].name == "Search Engine"
+
+
+def test_from_directory_loads_template(tmp_path: Path) -> None:
+    """SpecsConfig.from_directory loads a PRD template from the conventional path."""
+    specs_dir = tmp_path / ".specleft" / "specs"
+    specs_dir.mkdir(parents=True)
+    templates_dir = tmp_path / ".specleft" / "templates"
+    templates_dir.mkdir()
+
+    # Write a custom template that matches bare titles.
+    (templates_dir / "prd-template.yml").write_text(
+        "version: '1.0'\n"
+        "features:\n"
+        "  heading_level: 2\n"
+        "  patterns:\n"
+        "    - '{title}'\n"
+        "scenarios:\n"
+        "  heading_level: [3, 4]\n"
+        "  patterns:\n"
+        "    - 'Scenario: {title}'\n"
+        "priorities:\n"
+        "  patterns:\n"
+        "    - 'priority: {value}'\n"
+    )
+
+    (specs_dir / "notifications.md").write_text(
+        "# Push Notifications\n"
+        "\n"
+        "## Scenarios\n"
+        "\n"
+        "### Scenario: Send notification\n"
+        "priority: medium\n"
+        "\n"
+        "- Given a user is subscribed\n"
+        "- When an event occurs\n"
+        "- Then a notification is sent\n"
+    )
+
+    config = SpecsConfig.from_directory(specs_dir)
+    assert len(config.features) == 1
+    assert config.features[0].name == "Push Notifications"
+
+
+def test_from_directory_falls_back_without_template(tmp_path: Path) -> None:
+    """Without a template file, parser still uses default patterns + fallback."""
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+
+    # No .specleft/templates directory at all.
+    (specs_dir / "dashboard.md").write_text(
+        "# Feature: Admin Dashboard\n"
+        "\n"
+        "## Scenarios\n"
+        "\n"
+        "### Scenario: View metrics\n"
+        "priority: low\n"
+        "\n"
+        "- Given an admin user\n"
+        "- When viewing the dashboard\n"
+        "- Then metrics are displayed\n"
+    )
+
+    config = SpecsConfig.from_directory(specs_dir)
+    assert len(config.features) == 1
+    assert config.features[0].name == "Admin Dashboard"


### PR DESCRIPTION
## Summary

Fixes #85 — `specleft test skeleton`, `specleft features validate`, and `specleft features stats` all reported "No specs found" after `specleft plan` successfully created spec files.

## Root Cause

The parser (`parser.py`) required headings in strict `# Feature: <title>` format, but `plan` generates bare headings like `# Document Lifecycle` using the raw PRD heading text. Since the formats didn't match, all features were silently dropped.

## Changes

- **`src/specleft/parser.py`** — Make `SpecParser` template-aware: new `__init__` accepts an optional `PRDTemplate`, new `_extract_feature_heading()` tries each template pattern (most specific first) and falls back to raw heading text.
- **`src/specleft/schema.py`** — `SpecsConfig.from_directory()` now auto-resolves the PRD template from `.specleft/templates/prd-template.yml` and passes it to the parser.
- **`src/specleft/templates/prd_template.py`** — Added `"{title}"` catch-all to default feature and scenario pattern lists (last position, so more specific patterns are tried first).
- **`src/specleft/commands/init.py`** — Updated the init template content to match the new defaults.
- **`.specleft/templates/prd-template.yml`** — Updated project-local template with catch-all patterns.

## Tests

- 6 new parser tests covering `Feature:` prefix, bare title, custom template, `Feature` without colon, template auto-loading, and fallback without template file.
- 2 new end-to-end skeleton tests verifying generation from plan-style bare headings.
- 1 updated test for new default pattern expectations.
- All 440 tests pass, lint clean.