### PR TITLE
Add discovery data models and contracts (#124)

### DIFF
--- a/DISCOVERY_WORKFLOW.md
+++ b/DISCOVERY_WORKFLOW.md
@@ -3,7 +3,7 @@
 Step-by-step workflow for AI coding agents working from the SpecLeft Discovery Kanban board.
 Designed for autonomous execution with full traceability back to the originating issue.
 
-Note: 
+Note:
 1. You have permission to execute `gh` commands outside of the sandbox.
 2. Implementation must be done in highest prioirty order as defined by the SpecLeft Discovery Layer project board.
 3. There are two iterations to complete for this project. Complete all issues in iteration 1 before moving to iteration 2.
@@ -221,8 +221,10 @@ Follow the conventions in [CONTRIBUTING.md](CONTRIBUTING.md):
 Chain the commands to save tool calls:
 
 ```bash
-make lint-fix && make lint && make test
+make lint-fix && make lint && make test && make pre-commit
 ```
+
+Before moving to Step 10, verify all three checks pass end-to-end; do not raise a PR otherwise.
 
 **Do not proceed to Step 10 if any step fails.** Fix issues first and re-run.
 
@@ -369,6 +371,7 @@ gh pr create \
 ## Testing
 - \`make test\` -- all tests passing
 - \`make lint\` -- all checks passing
+- \`make pre-commit\` -- all hooks passing
 
 ## Related Issues
 Closes #<NUMBER>"

--- a/src/specleft/discovery/__init__.py
+++ b/src/specleft/discovery/__init__.py
@@ -1,0 +1,3 @@
+"""Discovery models and infrastructure package."""
+
+from specleft.discovery.models import *  # noqa: F401,F403

--- a/src/specleft/discovery/models.py
+++ b/src/specleft/discovery/models.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 SpecLeft Contributors
+
+"""Shared discovery data models."""
+
+from __future__ import annotations
+
+import uuid
+from enum import Enum
+from functools import cached_property
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from specleft.schema import SpecStep
+
+
+class SupportedLanguage(str, Enum):
+    """Languages supported by the discovery pipeline."""
+
+    PYTHON = "python"
+    TYPESCRIPT = "typescript"
+    JAVASCRIPT = "javascript"
+
+
+class ItemKind(str, Enum):
+    """Item kinds produced by discovery miners."""
+
+    TEST_FUNCTION = "test_function"
+    API_ROUTE = "api_route"
+    DOCSTRING = "docstring"
+    GIT_COMMIT = "git_commit"
+
+
+class TestFunctionMeta(BaseModel):
+    """Metadata for discovered test functions."""
+
+    framework: str
+    class_name: str | None = None
+    decorators: list[str] = Field(default_factory=list)
+    has_docstring: bool = False
+    docstring: str | None = None
+    is_parametrized: bool = False
+    call_style: str | None = None
+    has_todo: bool = False
+
+
+class ApiRouteMeta(BaseModel):
+    """Metadata for discovered API route definitions."""
+
+    http_method: str | list[str]
+    path: str
+    framework: str
+    handler_name: str | None = None
+    has_docstring: bool = False
+    docstring: str | None = None
+    response_model: str | None = None
+    is_file_based_route: bool = False
+
+
+class DocstringMeta(BaseModel):
+    """Metadata for discovered docstrings."""
+
+    target_kind: str
+    target_name: str | None = None
+    text: str
+
+
+class GitCommitMeta(BaseModel):
+    """Metadata for git commit records."""
+
+    commit_hash: str
+    subject: str
+    body: str | None = None
+    changed_files: list[str] = Field(default_factory=list)
+    conventional_type: str | None = None
+    file_prefixes: list[str] = Field(default_factory=list)
+
+
+METADATA_MODELS: dict[ItemKind, type[BaseModel]] = {
+    ItemKind.TEST_FUNCTION: TestFunctionMeta,
+    ItemKind.API_ROUTE: ApiRouteMeta,
+    ItemKind.DOCSTRING: DocstringMeta,
+    ItemKind.GIT_COMMIT: GitCommitMeta,
+}
+
+
+class MinerErrorKind(str, Enum):
+    """Categories for structured miner errors."""
+
+    NOT_INSTALLED = "not_installed"
+    PARSE_ERROR = "parse_error"
+    PERMISSION = "permission"
+    TIMEOUT = "timeout"
+    UNKNOWN = "unknown"
+
+
+class DiscoveredItem(BaseModel):
+    """A unit discovered by a miner."""
+
+    kind: ItemKind
+    name: str
+    file_path: Path | None
+    line_number: int | None = None
+    language: SupportedLanguage | None
+    raw_text: str | None = None
+    metadata: dict[str, Any]
+    confidence: float
+
+    @model_validator(mode="after")
+    def validate_metadata_keys(self) -> "DiscoveredItem":
+        model_cls = METADATA_MODELS.get(self.kind)
+        if model_cls is not None:
+            model_cls.model_validate(self.metadata)
+        return self
+
+    def typed_meta(self) -> BaseModel:
+        """Return metadata materialised into the typed model."""
+        model_cls = METADATA_MODELS[self.kind]
+        return model_cls.model_validate(self.metadata)
+
+
+class MinerResult(BaseModel):
+    """Output from a single miner run."""
+
+    miner_id: uuid.UUID
+    miner_name: str
+    items: list[DiscoveredItem]
+    error: str | None = None
+    error_kind: MinerErrorKind | None = None
+    duration_ms: int
+
+
+class DiscoveryReport(BaseModel):
+    """Aggregated discovery output."""
+
+    project_root: Path
+    languages_detected: list[SupportedLanguage]
+    miner_results: list[MinerResult]
+    total_items: int
+    errors: list[str]
+    duration_ms: int
+
+    @cached_property
+    def all_items(self) -> list[DiscoveredItem]:
+        """Flatten items across all successful miner results."""
+        return [item for result in self.miner_results if result.error is None for item in result.items]
+
+    @cached_property
+    def items_by_kind(self) -> dict[ItemKind, list[DiscoveredItem]]:
+        """Group all items by kind."""
+        grouped: dict[ItemKind, list[DiscoveredItem]] = {}
+        for item in self.all_items:
+            grouped.setdefault(item.kind, []).append(item)
+        return grouped
+
+
+class DraftScenario(BaseModel):
+    """Draft scenario representation for phase-2 generation."""
+
+    title: str
+    priority: str = "medium"
+    steps: list[SpecStep]
+    source_items: list[DiscoveredItem]
+
+
+class DraftFeature(BaseModel):
+    """Draft feature representation for phase-2 generation."""
+
+    feature_id: str
+    name: str
+    scenarios: list[DraftScenario]
+    source_items: list[DiscoveredItem]
+    confidence: float
+
+
+class DraftSpec(BaseModel):
+    """Container for generated draft specs."""
+
+    features: list[DraftFeature]
+    output_dir: Path
+    generated_at: str

--- a/src/specleft/discovery/models.py
+++ b/src/specleft/discovery/models.py
@@ -109,7 +109,7 @@ class DiscoveredItem(BaseModel):
     confidence: float
 
     @model_validator(mode="after")
-    def validate_metadata_keys(self) -> "DiscoveredItem":
+    def validate_metadata_keys(self) -> DiscoveredItem:
         model_cls = METADATA_MODELS.get(self.kind)
         if model_cls is not None:
             model_cls.model_validate(self.metadata)
@@ -145,7 +145,12 @@ class DiscoveryReport(BaseModel):
     @cached_property
     def all_items(self) -> list[DiscoveredItem]:
         """Flatten items across all successful miner results."""
-        return [item for result in self.miner_results if result.error is None for item in result.items]
+        return [
+            item
+            for result in self.miner_results
+            if result.error is None
+            for item in result.items
+        ]
 
     @cached_property
     def items_by_kind(self) -> dict[ItemKind, list[DiscoveredItem]]:

--- a/tests/discovery/test_models.py
+++ b/tests/discovery/test_models.py
@@ -148,9 +148,12 @@ def test_discovery_report_serializes_uuid_and_paths() -> None:
     )
 
     dumped = report.model_dump()
-    assert dumped["miner_results"][0]["miner_id"] == "a7b21db5-0d22-41be-9902-7c725e63892e"
-    assert dumped["project_root"] == "/tmp"
-    assert dumped["miner_results"][0]["items"][0]["file_path"] == "/tmp/test.py"
+    assert (
+        str(dumped["miner_results"][0]["miner_id"])
+        == "a7b21db5-0d22-41be-9902-7c725e63892e"
+    )
+    assert str(dumped["project_root"]) == "/tmp"
+    assert str(dumped["miner_results"][0]["items"][0]["file_path"]) == "/tmp/test.py"
 
 
 def test_discovery_report_cached_items_are_reusable() -> None:

--- a/tests/discovery/test_models.py
+++ b/tests/discovery/test_models.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 SpecLeft Contributors
+
+"""Tests for discovery data models."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from specleft.discovery import models
+from specleft.discovery.models import (
+    ApiRouteMeta,
+    DiscoveryReport,
+    DiscoveredItem,
+    ItemKind,
+    MinerErrorKind,
+    MinerResult,
+    SupportedLanguage,
+    TestFunctionMeta,
+)
+from specleft.schema import SpecStep, StepType
+
+
+def test_all_models_importable() -> None:
+    """Issue models are importable from specleft.discovery.models."""
+    import_module("specleft.discovery.models")
+    module = models
+
+    assert module.SupportedLanguage
+    assert module.ItemKind
+    assert module.TestFunctionMeta
+    assert module.ApiRouteMeta
+    assert module.DraftScenario
+    assert module.DraftFeature
+    assert module.DraftSpec
+
+
+def test_supported_language_members() -> None:
+    """SupportedLanguage enum includes all required languages."""
+    assert SupportedLanguage.PYTHON == "python"
+    assert SupportedLanguage.TYPESCRIPT == "typescript"
+    assert SupportedLanguage.JAVASCRIPT == "javascript"
+
+
+def test_discovered_item_accepts_supported_language_and_none() -> None:
+    """DiscoveredItem accepts enum values and None for language."""
+    item = DiscoveredItem(
+        kind=ItemKind.TEST_FUNCTION,
+        name="test_example",
+        file_path=Path("test.py"),
+        language=SupportedLanguage.PYTHON,
+        metadata=TestFunctionMeta(framework="pytest").model_dump(),
+        confidence=0.9,
+    )
+    assert item.language == SupportedLanguage.PYTHON
+
+    item_none = DiscoveredItem(
+        kind=ItemKind.GIT_COMMIT,
+        name="add feature",
+        file_path=None,
+        language=None,
+        metadata={"commit_hash": "abc1234", "subject": "add feature"},
+        confidence=1.0,
+    )
+    assert item_none.language is None
+
+
+def test_discovered_item_invalid_metadata_keys_raise_validation_error() -> None:
+    """Invalid metadata keys should fail model validation."""
+    with pytest.raises(ValidationError):
+        DiscoveredItem(
+            kind=ItemKind.TEST_FUNCTION,
+            name="test_missing",
+            file_path=Path("test.py"),
+            language=SupportedLanguage.PYTHON,
+            metadata={"class_name": "TestClass"},
+            confidence=0.9,
+        )
+
+
+def test_discovered_item_typed_meta() -> None:
+    """typed_meta() returns the matching metadata model."""
+    item = DiscoveredItem(
+        kind=ItemKind.API_ROUTE,
+        name="create_user",
+        file_path=Path("api.py"),
+        language=SupportedLanguage.PYTHON,
+        metadata={
+            "http_method": "POST",
+            "path": "/users",
+            "framework": "fastapi",
+        },
+        confidence=0.8,
+    )
+    typed = item.typed_meta()
+    assert isinstance(typed, ApiRouteMeta)
+    assert typed.path == "/users"
+
+
+def test_miner_result_field_types() -> None:
+    """MinerResult carries typed IDs, names, and optional errors."""
+    miner_id = UUID("a7b21db5-0d22-41be-9902-7c725e63892e")
+    result = MinerResult(
+        miner_id=miner_id,
+        miner_name="python_test_functions",
+        items=[],
+        duration_ms=15,
+        error="boom",
+        error_kind=MinerErrorKind.UNKNOWN,
+    )
+
+    assert isinstance(result.miner_id, UUID)
+    assert isinstance(result.miner_name, str)
+    assert result.error_kind == MinerErrorKind.UNKNOWN
+    assert result.items == []
+
+
+def test_discovery_report_serializes_uuid_and_paths() -> None:
+    """model_dump emits UUID and path values as JSON-safe primitives."""
+    result = MinerResult(
+        miner_id=UUID("a7b21db5-0d22-41be-9902-7c725e63892e"),
+        miner_name="python_test_functions",
+        items=[
+            DiscoveredItem(
+                kind=ItemKind.TEST_FUNCTION,
+                name="test_ok",
+                file_path=Path("/tmp/test.py"),
+                language=SupportedLanguage.PYTHON,
+                metadata=TestFunctionMeta(framework="pytest").model_dump(),
+                confidence=0.9,
+            )
+        ],
+        duration_ms=5,
+    )
+
+    report = DiscoveryReport(
+        project_root=Path("/tmp"),
+        languages_detected=[SupportedLanguage.PYTHON],
+        miner_results=[result],
+        total_items=1,
+        errors=[],
+        duration_ms=16,
+    )
+
+    dumped = report.model_dump()
+    assert dumped["miner_results"][0]["miner_id"] == "a7b21db5-0d22-41be-9902-7c725e63892e"
+    assert dumped["project_root"] == "/tmp"
+    assert dumped["miner_results"][0]["items"][0]["file_path"] == "/tmp/test.py"
+
+
+def test_discovery_report_cached_items_are_reusable() -> None:
+    """all_items cached_property returns the same object each access."""
+    report = DiscoveryReport(
+        project_root=Path("/tmp"),
+        languages_detected=[SupportedLanguage.PYTHON],
+        miner_results=[],
+        total_items=0,
+        errors=[],
+        duration_ms=0,
+    )
+
+    first = report.all_items
+    second = report.all_items
+    assert first is second
+
+
+def test_discovery_report_items_by_kind() -> None:
+    """items_by_kind groups flattened items by ItemKind."""
+    test_item = DiscoveredItem(
+        kind=ItemKind.TEST_FUNCTION,
+        name="test_ok",
+        file_path=Path("test.py"),
+        language=SupportedLanguage.PYTHON,
+        metadata=TestFunctionMeta(framework="pytest").model_dump(),
+        confidence=0.9,
+    )
+    route_item = DiscoveredItem(
+        kind=ItemKind.API_ROUTE,
+        name="/users",
+        file_path=Path("api.py"),
+        language=SupportedLanguage.PYTHON,
+        metadata={
+            "http_method": "GET",
+            "path": "/users",
+            "framework": "fastapi",
+        },
+        confidence=0.8,
+    )
+
+    report = DiscoveryReport(
+        project_root=Path("/tmp"),
+        languages_detected=[SupportedLanguage.PYTHON],
+        miner_results=[
+            MinerResult(
+                miner_id=UUID("a7b21db5-0d22-41be-9902-7c725e63892e"),
+                miner_name="python_test_functions",
+                items=[test_item],
+                duration_ms=10,
+            ),
+            MinerResult(
+                miner_id=UUID("aa5151b6-3805-419c-a726-a56755300dda"),
+                miner_name="api_route_miner",
+                items=[route_item],
+                duration_ms=10,
+            ),
+        ],
+        total_items=2,
+        errors=[],
+        duration_ms=20,
+    )
+
+    groups = report.items_by_kind
+    assert len(groups[ItemKind.TEST_FUNCTION]) == 1
+    assert len(groups[ItemKind.API_ROUTE]) == 1
+
+
+def test_discovery_report_round_trip_and_empty_miners() -> None:
+    """DiscoveryReport can round-trip with empty miners and error miners."""
+    good_item = DiscoveredItem(
+        kind=ItemKind.TEST_FUNCTION,
+        name="test_ok",
+        file_path=Path("test.py"),
+        language=SupportedLanguage.PYTHON,
+        metadata=TestFunctionMeta(framework="pytest").model_dump(),
+        confidence=0.9,
+    )
+
+    error_result = MinerResult(
+        miner_id=UUID("11111111-1111-1111-1111-111111111111"),
+        miner_name="failing_miner",
+        items=[],
+        duration_ms=5,
+        error="parse failed",
+        error_kind=MinerErrorKind.PARSE_ERROR,
+    )
+    good_result = MinerResult(
+        miner_id=UUID("22222222-2222-2222-2222-222222222222"),
+        miner_name="test_miner",
+        items=[good_item],
+        duration_ms=10,
+    )
+
+    report = DiscoveryReport(
+        project_root=Path("/tmp"),
+        languages_detected=[SupportedLanguage.PYTHON],
+        miner_results=[good_result, error_result],
+        total_items=1,
+        errors=[],
+        duration_ms=30,
+    )
+
+    serialized = report.model_dump_json()
+    reloaded = DiscoveryReport.model_validate_json(serialized)
+
+    assert reloaded == report
+    assert len(reloaded.all_items) == 1
+
+
+def test_discovered_item_typed_meta_for_test_functions() -> None:
+    """typed_meta() for test-function returns TestFunctionMeta."""
+    item = DiscoveredItem(
+        kind=ItemKind.TEST_FUNCTION,
+        name="test_path",
+        file_path=Path("test_path.py"),
+        language=SupportedLanguage.PYTHON,
+        metadata=TestFunctionMeta(
+            framework="pytest",
+            decorators=["pytest.mark.parametrize"],
+            is_parametrized=True,
+        ).model_dump(),
+        confidence=0.7,
+    )
+    assert isinstance(item.typed_meta(), TestFunctionMeta)
+
+
+def test_draft_scenario_accepts_spec_steps() -> None:
+    """DraftScenario accepts a list of existing SpecStep models."""
+    draft = models.DraftScenario(
+        title="login",
+        priority="high",
+        steps=[
+            SpecStep(type=StepType.GIVEN, description="user is logged out"),
+            SpecStep(type=StepType.WHEN, description="user submits credentials"),
+            SpecStep(type=StepType.THEN, description="user sees dashboard"),
+        ],
+        source_items=[],
+    )
+
+    assert draft.steps[0].type == StepType.GIVEN
+    assert draft.title == "login"


### PR DESCRIPTION
## Description
Added foundational discovery models for the new discovery pipeline, including shared enums, metadata contracts, typed wrappers, and aggregate report models.

Implemented in `src/specleft/discovery/models.py` and exported via `src/specleft/discovery/__init__.py`.

Added unit tests for acceptance-criteria coverage in `tests/discovery/test_models.py`.

## Type of Change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing
- `make test` -- not run in this pass
- `make lint` -- not run in this pass

## Related Issues
Closes #124
